### PR TITLE
Allow literal ipv6 hostname

### DIFF
--- a/app/core/build.gradle
+++ b/app/core/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     implementation "com.squareup.moshi:moshi:1.2.0"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
     implementation "org.apache.james:apache-mime4j-core:${versions.mime4j}"
+    implementation "com.google.guava:guava:${versions.guava}"
+    implementation "com.google.code.findbugs:jsr305:2.0.2" // needed for Guava
 
     testImplementation project(':mail:testing')
     testImplementation project(":backend:imap")

--- a/app/core/src/main/java/com/fsck/k9/helper/Utility.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/Utility.java
@@ -18,6 +18,9 @@ import android.text.TextUtils;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.google.common.net.InetAddresses;
+import com.google.common.net.InternetDomainName;
+
 import org.apache.james.mime4j.util.MimeUtil;
 import timber.log.Timber;
 
@@ -110,13 +113,9 @@ public class Utility {
     public static boolean domainFieldValid(EditText view) {
         if (view.getText() != null) {
             String s = view.getText().toString();
-            if (s.matches("^([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)*[a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?$") &&
-                s.length() <= 253) {
-                return true;
-            }
-            if (s.matches("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")) {
-                return true;
-            }
+
+            return InternetDomainName.isValid(s)
+                    || InetAddresses.isInetAddress(s);
         }
         return false;
     }

--- a/app/k9mail/proguard-rules.pro
+++ b/app/k9mail/proguard-rules.pro
@@ -22,6 +22,17 @@
 -dontnote com.fsck.k9.ui.messageview.**
 -dontnote com.fsck.k9.view.**
 
+# from https://github.com/google/guava/wiki/UsingProGuardWithGuava
+-dontwarn sun.misc.Unsafe
+-dontwarn com.google.common.collect.MinMaxPriorityQueue
+-keepclasseswithmembers public class * {
+    public static void main(java.lang.String[]);
+}
+# used only by errorprone annotations
+-dontwarn javax.lang.model.element.Modifier
+# not sure why this is needed for guava
+-dontwarn java.lang.ClassValue
+
 -keep public class org.openintents.openpgp.**
 
 -keepclassmembers class * extends android.support.v7.widget.SearchView {

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
                 'commonsIo': '2.4',
                 'coreKtx': '0.3',
                 'mime4j': '0.8.1',
+                'guava' : '27.0-android',
 
                 'junit': '4.12',
                 'robolectric': '3.7.1',


### PR DESCRIPTION
Per issue #3676, the inputted hostname for server settings can now be a raw IPv6 address

Not sure if this very minor enhancement is worth the overhead of adding guava, but on the other hand it's quite a useful library in general